### PR TITLE
Fixing tests for rider

### DIFF
--- a/07-Banking-Kata/csharp-dotnetcore2/BankingKataAPI.Test/ApiTest.cs
+++ b/07-Banking-Kata/csharp-dotnetcore2/BankingKataAPI.Test/ApiTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -7,15 +8,18 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Newtonsoft.Json;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace BankingKataAPI.Test
 {
     public class ApiTest : IDisposable
     {
+        private readonly ITestOutputHelper _output;
         private readonly TestServer _server;
 
-        public ApiTest()
+        public ApiTest(ITestOutputHelper output)
         {
+            _output = output;
             _server = new TestServer(new WebHostBuilder().UseStartup<Startup>());
         }
 

--- a/07-Banking-Kata/csharp-dotnetcore2/BankingKataAPI.Test/ApiTest.cs
+++ b/07-Banking-Kata/csharp-dotnetcore2/BankingKataAPI.Test/ApiTest.cs
@@ -8,18 +8,15 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Newtonsoft.Json;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace BankingKataAPI.Test
 {
     public class ApiTest : IDisposable
     {
-        private readonly ITestOutputHelper _output;
         private readonly TestServer _server;
 
-        public ApiTest(ITestOutputHelper output)
+        public ApiTest()
         {
-            _output = output;
             _server = new TestServer(new WebHostBuilder().UseStartup<Startup>());
         }
 

--- a/07-Banking-Kata/csharp-dotnetcore2/BankingKataAPI/Models/Money.cs
+++ b/07-Banking-Kata/csharp-dotnetcore2/BankingKataAPI/Models/Money.cs
@@ -31,11 +31,17 @@ namespace BankingKataAPI.Models
         public Money(decimal amount, CultureInfo cultureInfo)
         {
             _cultureInfo = cultureInfo ?? throw new ArgumentNullException("cultureInfo");
-
-            _regionInfo = new RegionInfo(cultureInfo.LCID);
+            _regionInfo = GetRegionOrDefault(cultureInfo);
 
             LongAmount = Convert.ToInt64(Math.Round(amount * CentFactor));
 
+        }
+
+        private static RegionInfo GetRegionOrDefault(CultureInfo cultureInfo)
+        {
+            if (Equals(cultureInfo, CultureInfo.InvariantCulture))
+                return RegionInfo.CurrentRegion;
+            return new RegionInfo(cultureInfo.LCID);
         }
 
         [JsonConstructor]


### PR DESCRIPTION
Updating Money to use the provided culture if it has a valid region otherwise defaulting to the current region of the machine.

This fixes the following issue when running the tests in Rider: 

```
Exception thrown: System.ArgumentException : There is no region associated with the Invariant Culture (Culture ID: 0x7F).
```