### PR TITLE
update fizzbuzz to net5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build
 .idea
 .iml
 .suo
+*.DotSettings.user
 
 # build
 [Oo]bj/

--- a/01-FizzBuzz/csharp-dotnetcore/FizzBuzz/FizzBuzz.csproj
+++ b/01-FizzBuzz/csharp-dotnetcore/FizzBuzz/FizzBuzz.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>default</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/01-FizzBuzz/csharp-dotnetcore/FizzBuzzTest/FizzBuzzTest.cs
+++ b/01-FizzBuzz/csharp-dotnetcore/FizzBuzzTest/FizzBuzzTest.cs
@@ -6,11 +6,11 @@ namespace Katas
     public class FizzBuzzTest
     {
         [Fact]
-        public void ShouldReturn1For1()
+        public void Returns1For1()
         {
-            FizzBuzz fizzBuzz = new FizzBuzz();
-            string actualReturnValue = fizzBuzz.Process(1);
-            string expectedReturnValue = "1";
+            var fizzBuzz = new FizzBuzz();
+            var actualReturnValue = fizzBuzz.Process(1);
+            var expectedReturnValue = "1";
             Assert.Equal(expectedReturnValue, actualReturnValue);
         }
     }

--- a/01-FizzBuzz/csharp-dotnetcore/FizzBuzzTest/FizzBuzzTest.csproj
+++ b/01-FizzBuzz/csharp-dotnetcore/FizzBuzzTest/FizzBuzzTest.csproj
@@ -1,9 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>default</LangVersion>
+
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I want to update all the exercises for C#, and possibly add the Python versions.  For now, I just want to know that I can get a PR completed.